### PR TITLE
Install with pbr

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,24 @@
     "python.linting.mypyEnabled": true,
     "python.testing.pytestEnabled": true,
     "cSpell.words": [
+        "LGP",
+        "Lv",
+        "OSI",
+        "appscript",
         "atexit",
-        "pygame"
+        "audiogame",
+        "bgt",
+        "bson",
+        "cmdclass",
+        "luciasoftware",
+        "openal",
+        "pbr",
+        "pycryptodomex",
+        "pygame",
+        "pypiwin",
+        "pysoundfile",
+        "pytest",
+        "pywin",
+        "versioneer"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
-    "python.pythonPath": "C:\\Users\\nickl\\AppData\\Local\\pypoetry\\Cache\\virtualenvs\\lucia-9cOskZfG-py3.8\\Scripts\\python.exe",
     "python.venvPath": "~/AppData/Local/pypoetry/Cache/virtualenvs",
     "python.linting.flake8Args": [
         "--max-line-length=88"
@@ -9,5 +8,9 @@
     "editor.formatOnSave": true,
     "python.formatting.provider": "black",
     "python.linting.mypyEnabled": true,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "cSpell.words": [
+        "atexit",
+        "pygame"
+    ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+pygame
+pycryptodomex
+pysoundfile
+numpy==1.19.3
+sound_lib
+python-openal
+accessible_output2
+bson
+versioneer
+cytolk

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = lucia
+description = A cross platform, feature rich audio game engine written in Python.
+description-file = README.md
+description-content-type = text/markdown
+home-page = http://github.com/LuciaSoftware/lucia
+author = Lucia Software
+author-email = NicklasMCHD@live.dk
+license = LGPL
+
+[tool:pytest]
+testpaths = "tests"
+addopts = "-q"
+
+[flake8]
+exclude = env, .eggs, build
+
+[build_sphinx]
+builders = html
+source-dir = docs
+build-dir = docs
+all-files = 1
+
+[entry_points]
+console_scripts =
+    lucia.packer = lucia.cli.packer:main
+    lucia=lucia.cli:main
+
+[options]
+install_requires =
+    appscript;platform_system=='Darwin'
+    pywin32;platform_system=='Windows'
+    pypiwin32;platform_system=='Windows'

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+"""The setup script for the Lucia module."""
+
+from setuptools import setup
+
+setup(setup_requires=["pbr", "setuptools", "pytest-runner"], pbr=True)


### PR DESCRIPTION
## What has changed

- Created a `setup.cfg` file with all the defaults from the old `setup.py` file.
- Created a `setup.py` file with the defaults required by PBR.
- Tested on my system, and determined that everything still works: I can create a blank virtual environment, then do `python setup.py develop`. Everything installs, and `pytest` runs fine.